### PR TITLE
use before-send timestamp as previous frame timestamp

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -280,8 +280,8 @@ async fn send_json(
         let duration1 = Instant::now();
         let duration = duration1 - duration0;
         println!("  send_json: emit duration: {} microsec.", duration.as_micros());
-        // 今回送信終了した時刻を前回送信時刻として保持する。
-        timestamp_prev = duration1;
+        // 送信にかかった時間は加算せず、今回送信を開始した時刻を保存しておく。
+        timestamp_prev = duration0;
       }
       // *counter.0.lock().await += 1;
       *counter.0.lock().await = i + 1;  // 他のスレッドから書き換えられる可能性を考えるとi+1


### PR DESCRIPTION
#12
これまでは、送信が終わったタイミングから次のフレームのタイムスタンプまで待機していましたが、
これだと送信にかかった時間が徐々に加算されていくことになり、これが遅れにつながったのではないかと思われます。
送信を開始したタイミングから待機するように変更したことで、目視では遅れがないように見えます。